### PR TITLE
Worktime tracking

### DIFF
--- a/src/components/CalendarField.vue
+++ b/src/components/CalendarField.vue
@@ -40,7 +40,7 @@
     :color="configurationStore.isDarkMode ? 'blue-grey' : 'blue'"
     :disable="configurationStore.isHolidayMode && day.holiday?.isHoliday"
     v-model.number="day.vacationHours"
-    v-if="currentSelected.value === selectOptions[2].value"
+    v-if="currentSelected.value === selectOptions[1].value"
   >
     <q-btn-dropdown flat dense class="button-dropdown" size="md">
       <template v-slot:label>
@@ -75,7 +75,7 @@
     v-model.number="day.sicknessHours"
     v-if="
       selectOptionsRefContains('sick') &&
-      currentSelected.value === selectOptions[3].value &&
+      currentSelected.value === selectOptions[2].value &&
       configurationStore.isSicknessMode
     "
   >
@@ -158,7 +158,6 @@ interface SelectOption {
 
 const selectOptions: Array<SelectOption> = [
   { label: "work", value: "Hours", icon: "o_schedule" },
-  { label: "break", value: "Break", icon: "o_lunch_dining" },
   { label: "vacation", value: "Vacation", icon: "o_beach_access" },
   { label: "sick", value: "Sickness", icon: "o_sick" },
 ];

--- a/src/components/CalendarField.vue
+++ b/src/components/CalendarField.vue
@@ -1,11 +1,11 @@
 <template>
   <q-input
     class="day-input"
-    type="number"
     filled
     :color="configurationStore.isDarkMode ? 'blue-grey' : 'blue'"
     :disable="configurationStore.isHolidayMode && day.holiday?.isHoliday"
     v-model="calculateTimeTest"
+    readonly
     v-if="currentSelected.value === selectOptions[0].value"
   >
     <q-btn-dropdown flat dense class="button-dropdown" size="md">
@@ -78,7 +78,7 @@
       configurationStore.isSicknessMode
     "
   >
-    <q-btn-dropdown flat dense class="button-dropdown" size="md">
+    <q-btn-dropdown flat dense class="button-dropdown" size="md" >
       <template v-slot:label>
         <div class="row items-center no-wrap">
           <q-icon left :name="currentSelected.icon" />
@@ -105,6 +105,7 @@
   <q-expansion-item
       v-model="expanded"
       icon="calculate"
+      :disable="currentSelected.value !== selectOptions[0].value" 
     >
       <q-input
         type="text"
@@ -165,7 +166,7 @@ const getDateFromInput = (time: string): Date => {
   return date;
 };
 
-const calculateTimeTest = computed<undefined | number>(()  => {
+const calculateTimeTest = computed(()  => {
   if (props.day.begin && props.day.pause && props.day.end){
     const dateEndTime = getDateFromInput(props.day.end);
     const dateBeginTime = getDateFromInput(props.day.begin);
@@ -175,14 +176,14 @@ const calculateTimeTest = computed<undefined | number>(()  => {
     temp = subMinutes(temp, dateBeginTime.getMinutes());
     temp = subHours(temp, datePauseTime.getHours());
     temp = subHours(temp, dateBeginTime.getHours());
-    
     const hour = temp.getHours();
     const minutesInHours = temp.getMinutes() / 60;
-    const calculatedNumber = parseFloat(n(hour + minutesInHours, "decimal", locale.value))
-    if (!isNaN(calculatedNumber)) {
+    const calculatedString = n(hour + minutesInHours, "decimal", locale.value)
+    if (!calculatedString || calculatedString === undefined || calculatedString === "") {
       return props.day.hours 
     }
-    return calculatedNumber
+
+    return calculatedString
   }
       return props.day.hours 
 })

--- a/src/models/month-model.ts
+++ b/src/models/month-model.ts
@@ -14,14 +14,21 @@ export interface IWeekModel {
 export interface IDayModelRef {
   day: Date;
   hours: Ref<number>;
+  begin: Ref<string>;
+  end: Ref<string>;
+  pause: Ref<string>;
 }
 
+// This model is used to save Day
 export interface IDayModel {
   day: Date;
   hours: number;
   vacationHours: number;
   sicknessHours: number;
   holiday: IHolidayModel;
+  begin: string;
+  end: string;
+  pause: string;
 }
 
 export interface IHolidayModel {

--- a/src/stores/useTimekeepingStore.ts
+++ b/src/stores/useTimekeepingStore.ts
@@ -17,6 +17,9 @@ export default defineStore("timekeepingStore", {
     async saveData() {
       const { data } = this;
       try {
+        debugger;
+        console.log("test")
+        console.log(data)
         await createFile("data", JSON.stringify(data));
         console.log("Successfully saved data");
       } catch (error) {

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -33,6 +33,9 @@ const getAllDaysOfMonth = (date: Date) => {
       week[dayName] = {
         day: new Date(tempDate),
         hours: ref(0),
+        begin: ref(0),
+        end: ref(0),
+        pause: ref(0),
       };
     }
 

--- a/src/views/Timekeeping.vue
+++ b/src/views/Timekeeping.vue
@@ -159,6 +159,9 @@ const inputValues = computed(() => {
                 sicknessHours: 0,
                 vacationHours: 0,
                 holiday: isHoliday(weekDay.day),
+                begin: "",
+                end: "",
+                pause: "",
               },
             };
           } else {
@@ -168,6 +171,9 @@ const inputValues = computed(() => {
               sicknessHours: 0,
               vacationHours: 0,
               holiday: isHoliday(weekDay.day),
+              begin: "",
+              end: "",
+              pause: "",
             };
           }
         }
@@ -230,8 +236,10 @@ const calculateOvertime = (cw: number) => {
 
 const onSave = async () => {
   try {
+    debugger;
     await timeKeeperStore.saveData();
     usePopupStore().showPopup(t, true);
+    debugger;
   } catch (error) {
     console.error("Could not write configuration.json.");
     usePopupStore().showPopup(t);


### PR DESCRIPTION
Added the functionality to track the begin, end and break time for each day.
These fields generate the total work time of the selected day.
The total work time is now read from disk or will be generated via a computed prop.

This feature can replace the "time calculator" tab.

![image](https://user-images.githubusercontent.com/53406799/219793030-42523b67-153c-4d7e-9e32-50e1b0585b25.png)

⚠️ This feature **should** be compatible with old versions, but no gurantee! 